### PR TITLE
Exclude undefined keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,9 @@ Params.prototype.only = function(args) {
   var obj = {};
 
   allowed.forEach(function(key) {
-    obj[key] = this.hash[key];
+    if (this.hash.hasOwnProperty(key)) {
+      obj[key] = this.hash[key];
+    }
   }, this);
 
   return obj;

--- a/test/params.js
+++ b/test/params.js
@@ -5,12 +5,15 @@
 var fixture = { foo: 'bar', baz: 'zo', cl: 'fn' };
 
 test('params(x).only(y)', function() {
-  var actual = null
+  var actual = null;
 
   actual = params(fixture).only('foo', 'baz');
   actual.should.eql({ foo: 'bar', baz: 'zo' });
 
   actual = params(fixture).only(['foo', 'baz']);
+  actual.should.eql({ foo: 'bar', baz: 'zo' });
+
+  actual = params(fixture).only('foo', 'baz', 'not_defined');
   actual.should.eql({ foo: 'bar', baz: 'zo' });
 });
 


### PR DESCRIPTION
Today params creates undefined attributes for each whitelisted value.

``` js
actual = params({ foo: 'bar', baz: 'zo', cl: 'fn' }).only('foo', 'baz', 'not_defined');
{ foo: 'bar', baz: 'zo', not_defined: undefined }
```

This breaks our filtering as not send values are now present as undefined.
