### PR TITLE
permit(Array) support

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 
-0.1.1 / 2014-11-03 
+0.2.0 / 2016-05-01
+==================
+
+  * permit(array)
+
+0.1.1 / 2014-11-03
 ==================
 
  * Merge pull request #3 from johanneswuerbach/exclude-undefined

--- a/Readme.md
+++ b/Readme.md
@@ -48,10 +48,8 @@ Like `#only`, but mutates the object.
 ```js
 var hash = { foo: 1, bar: 2, baz: 3 };
 
-params(hash)
-  .permit('foo')
-  .permit('baz')
-  .slice()
+params(hash).permit('foo').permit('baz').slice()
+params(hash).permit(['foo', 'baz']).slice()
 
 console.log(hash);
 

--- a/index.js
+++ b/index.js
@@ -291,15 +291,17 @@ Params.prototype.require = function(args) {
 };
 
 /**
- * Permit given "key".
+ * Permit given "key(s)".
  *
- * @param {String} key
+ * @param {Array|String} key
  * @returns {Params} `this`
  * @api public
  */
 
 Params.prototype.permit = function(key) {
-  this.allowed.push(key);
+  [].concat(key).forEach(function(key) {
+    this.allowed.push(key);
+  }, this)
   return this;
 };
 

--- a/test/params.js
+++ b/test/params.js
@@ -47,3 +47,13 @@ test('params(x).permit(y).slice()', function() {
 
   fixture.should.eql({ foo: 'bar', baz: 'zo' });
 });
+
+test('params(x, y, z).permit([x, y]).slice()', function() {
+  var fixture = { foo: 'bar', baz: 'zo', cl: 'fn' };
+
+  params(fixture)
+    .permit(['foo', 'baz'])
+    .slice();
+
+  fixture.should.eql({ foo: 'bar', baz: 'zo' });
+});


### PR DESCRIPTION
Allows consumer to specify an array of properties to `permit()`.  This is nice in situations where there are a large number of properties:

``` js
// original:
params(fixture)
    .permit('foo')
    .permit('bar')
    .permit('baz')
    .permit('omg')
    .permit('hi')
    .permit('vesln')
    .permit('!')
    .slice();

// vs

params(fixture)
    .permit(['foo', 'bar', 'baz', 'omg', 'hi', 'vesln', '!')
    .slice();
```

cc @vesln @logicalparadox 
